### PR TITLE
not returning error on 'unknown' runtime version anymore

### DIFF
--- a/cmd/provision/config.go
+++ b/cmd/provision/config.go
@@ -186,7 +186,8 @@ func (p *provision) checkRuntimeVersion(config *server.Config, client *http.Clie
 		return "", fmt.Errorf("response has no 'platform' field")
 	}
 	if version == "unknown" {
-		return "", fmt.Errorf("runtime version unknown")
+		verbosef("runtime version unknown")
+		return "unknown", nil
 	}
 
 	return version, nil

--- a/cmd/provision/config.go
+++ b/cmd/provision/config.go
@@ -187,7 +187,6 @@ func (p *provision) checkRuntimeVersion(config *server.Config, client *http.Clie
 	}
 	if version == "unknown" {
 		verbosef("runtime version unknown")
-		return "unknown", nil
 	}
 
 	return version, nil

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -256,7 +256,10 @@ func (p *provision) run(printf shared.FormatFn) error {
 		return errors.Wrapf(err, "generating config")
 	}
 
-	verbosef("provisioning verified OK")
+	if verifyErrors == nil {
+		verbosef("provisioning verified OK")
+	}
+
 	return verifyErrors
 }
 
@@ -353,7 +356,7 @@ func (p *provision) verify(config *server.Config, verbosef shared.FormatFn) erro
 		if version, err := p.checkRuntimeVersion(config, client, verbosef); err != nil {
 			err = errors.Wrapf(err, "Unable to get the runtime version")
 			verifyErrors = multierr.Combine(verifyErrors, err)
-		} else if version >= "1.3.0" {
+		} else if version >= "1.3.0" || version == "unknown" {
 			p.encodeUDCAEndpoint(config, verbosef)
 		}
 	}

--- a/cmd/provision/provision_test.go
+++ b/cmd/provision/provision_test.go
@@ -520,8 +520,9 @@ func TestUnknownRuntimeVersion(t *testing.T) {
 	rootCmd := cmd.GetRootCmd(flags, print.Printf)
 	shared.AddCommandWithFlags(rootCmd, rootArgs, testCmd(rootArgs, print.Printf, ts.URL))
 
-	err := rootCmd.Execute()
-	testutil.ErrorContains(t, err, "Unable to get the runtime version: runtime version unknown")
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("want no error: %v", err)
+	}
 }
 
 func TestAPIProductCreation(t *testing.T) {


### PR DESCRIPTION
better resolves #18 

Also, verbosef does not print "provisioning verified OK" unconditionally any longer.