### PR TITLE
added --management, -m flag  for bindings service

### DIFF
--- a/cmd/bindings/bindings.go
+++ b/cmd/bindings/bindings.go
@@ -46,7 +46,7 @@ func Cmd(rootArgs *shared.RootArgs, printf shared.FormatFn) *cobra.Command {
 		Short: "Manage Apigee Product to Remote Target bindings",
 		Long:  "Manage Apigee Product to Remote Target bindings.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return rootArgs.Resolve(false, true)
+			return rootArgs.Resolve(false, false)
 		},
 	}
 
@@ -60,6 +60,8 @@ func Cmd(rootArgs *shared.RootArgs, printf shared.FormatFn) *cobra.Command {
 		"Apigee username (legacy or OPDK only)")
 	c.PersistentFlags().StringVarP(&rootArgs.Password, "password", "p", "",
 		"Apigee password (legacy or OPDK only)")
+	c.PersistentFlags().StringVarP(&rootArgs.ManagementBase, "management", "m",
+		"", "Apigee management base URL")
 
 	c.AddCommand(cmdBindingsList(cfg, printf))
 	c.AddCommand(cmdBindingsAdd(cfg, printf))

--- a/cmd/bindings/bindings_test.go
+++ b/cmd/bindings/bindings_test.go
@@ -205,23 +205,12 @@ func testBindingsParams(t *testing.T, args ...string) {
 	var flags []string
 	var rootCmd *cobra.Command
 	var rootArgs *shared.RootArgs
+	var wantErr string
 	print := testutil.Printer("TestBindingsParams")
 
-	// hybrid no args
-	wantErr := "--runtime is required for hybrid or opdk (or --organization and --environment with --legacy)"
-	flags = []string{"bindings"}
-	flags = append(flags, args...)
-	rootArgs = &shared.RootArgs{}
-	rootCmd = cmd.GetRootCmd(flags, print.Printf)
-	shared.AddCommandWithFlags(rootCmd, rootArgs, Cmd(rootArgs, print.Printf))
-	err = rootCmd.Execute()
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("%v want %s, got: %v", args, wantErr, err)
-	}
-
-	// hybrid requires runtime
-	wantErr = "--runtime is required for hybrid or opdk (or --organization and --environment with --legacy)"
-	flags = []string{"bindings", "-o", "/org/", "-e", "/env/"}
+	// opdk no args
+	wantErr = "--runtime or --config is required and used as the management url if --management is not explicitly set for opdk"
+	flags = []string{"bindings", "--opdk"}
 	flags = append(flags, args...)
 	rootArgs = &shared.RootArgs{}
 	rootCmd = cmd.GetRootCmd(flags, print.Printf)
@@ -244,7 +233,7 @@ func testBindingsParams(t *testing.T, args ...string) {
 	}
 
 	// legacy requires org & env
-	wantErr = "--organization and --environment are required"
+	wantErr = "--organization and --environment are required for legacy saas"
 	flags = []string{"bindings", "--legacy", "--runtime", "/runtime/"}
 	flags = append(flags, args...)
 	rootArgs = &shared.RootArgs{}

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -50,8 +50,8 @@ const (
 
 // default durations for the proxy verification retry
 var (
-	duration time.Duration = 180  // second
-	interval time.Duration = 5000 // millisecond
+	duration time.Duration = 180000 // millisecond
+	interval time.Duration = 5000   // millisecond
 )
 
 type provision struct {
@@ -296,7 +296,7 @@ func (p *provision) createAuthorizedClient(config *server.Config) (*http.Client,
 
 func (p *provision) verifyWithRetry(config *server.Config, verbosef shared.FormatFn) error {
 	var verifyErrors error
-	timeout := time.After(duration * time.Second)
+	timeout := time.After(duration * time.Millisecond)
 	tick := time.Tick(interval * time.Millisecond)
 	for {
 		select {

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -50,8 +50,8 @@ const (
 
 // default durations for the proxy verification retry
 var (
-	duration time.Duration = 180000 // millisecond
-	interval time.Duration = 5000   // millisecond
+	duration time.Duration = 180 * time.Second
+	interval time.Duration = 5 * time.Second
 )
 
 type provision struct {
@@ -296,8 +296,8 @@ func (p *provision) createAuthorizedClient(config *server.Config) (*http.Client,
 
 func (p *provision) verifyWithRetry(config *server.Config, verbosef shared.FormatFn) error {
 	var verifyErrors error
-	timeout := time.After(duration * time.Millisecond)
-	tick := time.Tick(interval * time.Millisecond)
+	timeout := time.After(duration)
+	tick := time.Tick(interval)
 	for {
 		select {
 		case <-timeout:

--- a/cmd/provision/provision_test.go
+++ b/cmd/provision/provision_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apigee/apigee-remote-service-cli/apigee"
 	"github.com/apigee/apigee-remote-service-cli/cmd"
@@ -41,8 +42,8 @@ func TestVerifyRemoteServiceProxyTLS(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	duration = 200
-	interval = 100
+	duration = 200 * time.Millisecond
+	interval = 100 * time.Millisecond
 
 	// try without InsecureSkipVerify
 	p := &provision{
@@ -389,8 +390,8 @@ func TestProvisionHybrid(t *testing.T) {
 	ts := httptest.NewServer(handler(t))
 	defer ts.Close()
 
-	duration = 200
-	interval = 100
+	duration = 200 * time.Millisecond
+	interval = 100 * time.Millisecond
 
 	print := testutil.Printer("TestProvisionHybrid")
 
@@ -448,8 +449,8 @@ func TestInvalidRuntimeVersion(t *testing.T) {
 	ts := httptest.NewServer(badHandler(t))
 	defer ts.Close()
 
-	duration = 200
-	interval = 100
+	duration = 200 * time.Millisecond
+	interval = 100 * time.Millisecond
 
 	print := testutil.Printer("TestRuntimeVersion")
 
@@ -480,8 +481,8 @@ func TestMissingRuntimeVersion(t *testing.T) {
 	ts := httptest.NewServer(badHandler(t))
 	defer ts.Close()
 
-	duration = 200
-	interval = 100
+	duration = 200 * time.Millisecond
+	interval = 100 * time.Millisecond
 
 	print := testutil.Printer("TestRuntimeVersion")
 
@@ -512,8 +513,8 @@ func TestUnknownRuntimeVersion(t *testing.T) {
 	ts := httptest.NewServer(badHandler(t))
 	defer ts.Close()
 
-	duration = 200
-	interval = 100
+	duration = 200 * time.Millisecond
+	interval = 100 * time.Millisecond
 
 	print := testutil.Printer("TestRuntimeVersion")
 

--- a/cmd/provision/provision_test.go
+++ b/cmd/provision/provision_test.go
@@ -41,8 +41,8 @@ func TestVerifyRemoteServiceProxyTLS(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	duration = 1
-	interval = 500
+	duration = 200
+	interval = 100
 
 	// try without InsecureSkipVerify
 	p := &provision{
@@ -51,6 +51,8 @@ func TestVerifyRemoteServiceProxyTLS(t *testing.T) {
 			Token:              "-",
 			InsecureSkipVerify: false,
 			IsLegacySaaS:       true,
+			Org:                "hi",
+			Env:                "test",
 		},
 	}
 	if err := p.Resolve(false, false); err != nil {
@@ -387,8 +389,8 @@ func TestProvisionHybrid(t *testing.T) {
 	ts := httptest.NewServer(handler(t))
 	defer ts.Close()
 
-	duration = 1
-	interval = 500
+	duration = 200
+	interval = 100
 
 	print := testutil.Printer("TestProvisionHybrid")
 
@@ -446,8 +448,8 @@ func TestInvalidRuntimeVersion(t *testing.T) {
 	ts := httptest.NewServer(badHandler(t))
 	defer ts.Close()
 
-	duration = 1
-	interval = 500
+	duration = 200
+	interval = 100
 
 	print := testutil.Printer("TestRuntimeVersion")
 
@@ -478,8 +480,8 @@ func TestMissingRuntimeVersion(t *testing.T) {
 	ts := httptest.NewServer(badHandler(t))
 	defer ts.Close()
 
-	duration = 1
-	interval = 500
+	duration = 200
+	interval = 100
 
 	print := testutil.Printer("TestRuntimeVersion")
 
@@ -510,8 +512,8 @@ func TestUnknownRuntimeVersion(t *testing.T) {
 	ts := httptest.NewServer(badHandler(t))
 	defer ts.Close()
 
-	duration = 1
-	interval = 500
+	duration = 200
+	interval = 100
 
 	print := testutil.Printer("TestRuntimeVersion")
 

--- a/cmd/token/token_test.go
+++ b/cmd/token/token_test.go
@@ -139,12 +139,21 @@ func TestTokenCreate(t *testing.T) {
 
 	print.Check(t, want)
 
+	// bad runtime
 	flags = []string{"token", "create", "--runtime", "dummy", "--id", "/id/", "--secret", "/secret/"}
 	rootCmd = cmd.GetRootCmd(flags, print.Printf)
 	shared.AddCommandWithFlags(rootCmd, rootArgs, Cmd(rootArgs, print.Printf))
 
 	err := rootCmd.Execute()
 	testutil.ErrorContains(t, err, "creating token: Post \"dummy/remote-service/token\": unsupported protocol scheme")
+
+	// missing runtime
+	flags = []string{"token", "create", "--id", "/id/", "--secret", "/secret/"}
+	rootCmd = cmd.GetRootCmd(flags, print.Printf)
+	shared.AddCommandWithFlags(rootCmd, rootArgs, Cmd(rootArgs, print.Printf))
+
+	err = rootCmd.Execute()
+	testutil.ErrorContains(t, err, "--runtime is required for hybrid or opdk (or --organization and --environment with --legacy)")
 }
 
 func TestTokenInspect(t *testing.T) {


### PR DESCRIPTION
and now --runtime, -r is optional there.

fix #29 