### PR TITLE
App bindings linter

### DIFF
--- a/apigee/app.go
+++ b/apigee/app.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apigee
+
+type Application struct {
+	AppID          string          `json:"appId"`
+	Attributes     []interface{}   `json:"attributes,omitempty"`
+	APIProducts    []APIProductRef `json:"apiProducts,omitempty"`
+	CallBackURL    string          `json:"callbackUrl,omitempty"`
+	CreatedAt      string          `json:"createdAt,omitempty"`
+	Credentials    []Credential    `json:"credentials,omitempty"`
+	CompanyName    string          `json:"companyName,omitempty"`
+	DeveloperID    string          `json:"developerId,omitempty"`
+	LastModifiedAt string          `json:"lastModifiedAt,omitempty"`
+	Name           string          `json:"name"`
+	Scopes         []string        `json:"scopes,omitempty"`
+	Status         string          `json:"status,omitempty"`
+}
+
+type Credential struct {
+	APIProducts []APIProductRef `json:"apiProducts,omitempty"`
+}
+
+type AppResponse struct {
+	Apps []Application `json:"app,omitempty"`
+}
+
+type APIProductRef struct {
+	Name   string `json:"apiproduct"`
+	Status string `json:"status,omitempty"`
+}

--- a/cmd/bindings/bindings.go
+++ b/cmd/bindings/bindings.go
@@ -393,7 +393,6 @@ func (b *bindings) updateTargetBindings(p *product.APIProduct, bindings []string
 	if err != nil {
 		return err
 	}
-	//req.URL.Path = path // hack: negate client's base URL
 	var attrResult attrUpdate
 	_, err = b.ApigeeClient.Do(req, &attrResult)
 	return err

--- a/cmd/bindings/bindings.go
+++ b/cmd/bindings/bindings.go
@@ -195,6 +195,7 @@ func (b *bindings) getProduct(name string) (*product.APIProduct, error) {
 	resp, err := b.ApigeeClient.Do(req, p)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			defer resp.Body.Close()
 			return nil, nil
 		}
 		return nil, errors.Wrap(err, "retrieving products")

--- a/cmd/bindings/bindings_test.go
+++ b/cmd/bindings/bindings_test.go
@@ -89,6 +89,28 @@ func TestBindingListOPDK(t *testing.T) {
 		"\n",
 	}
 	print.Check(t, wants)
+
+	flags = []string{"bindings", "list", "/product2/", "--opdk", "--runtime", ts.URL,
+		"-o", "/org/", "-e", "/env/", "-u", "/username/", "-p", "password"}
+	rootArgs = &shared.RootArgs{}
+	rootCmd = cmd.GetRootCmd(flags, print.Printf)
+	shared.AddCommandWithFlags(rootCmd, rootArgs, Cmd(rootArgs, print.Printf))
+	if err = rootCmd.Execute(); err != nil {
+		t.Errorf("want no error, got: %v", err)
+	}
+	wants = []string{
+		"\nAPI Products\n============",
+		"\nBound\n-----",
+		"\n",
+		"/product2/",
+		":",
+		"\n  Target bindings:",
+		"\n    ",
+		"/target/",
+		"\n  Paths:",
+		"\n",
+	}
+	print.Check(t, wants)
 }
 
 func TestBindingAddOPDK(t *testing.T) {

--- a/cmd/bindings/bindings_test.go
+++ b/cmd/bindings/bindings_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/apigee/apigee-remote-service-cli/apigee"
 	"github.com/apigee/apigee-remote-service-cli/cmd"
 	"github.com/apigee/apigee-remote-service-cli/shared"
 	"github.com/apigee/apigee-remote-service-cli/testutil"
@@ -58,7 +59,21 @@ func TestBindingListOPDK(t *testing.T) {
 		"\nAPI Products\n============",
 		"\nBound\n-----",
 		"\n",
+		"/product0/",
+		":",
+		"\n  Target bindings:",
+		"\n    ",
+		"/target/",
+		"\n  Paths:",
+		"\n",
 		"/product2/",
+		":",
+		"\n  Target bindings:",
+		"\n    ",
+		"/target/",
+		"\n  Paths:",
+		"\n",
+		"/product4/",
 		":",
 		"\n  Target bindings:",
 		"\n    ",
@@ -168,9 +183,66 @@ func TestBindingRemoveOPDK(t *testing.T) {
 	print.Check(t, wants)
 }
 
+func TestBindingVerifyAll(t *testing.T) {
+	print := testutil.Printer("TestBindingVerify")
+	ts := productTestServer(t)
+	defer ts.Close()
+
+	var err error
+	var flags []string
+	var rootCmd *cobra.Command
+	var rootArgs *shared.RootArgs
+	var wants []string
+
+	flags = []string{"bindings", "verify", "--opdk", "--runtime", ts.URL,
+		"-o", "/org/", "-e", "/env/", "-u", "/username/", "-p", "password"}
+	rootArgs = &shared.RootArgs{}
+	rootCmd = cmd.GetRootCmd(flags, print.Printf)
+	shared.AddCommandWithFlags(rootCmd, rootArgs, Cmd(rootArgs, print.Printf))
+	if err = rootCmd.Execute(); err != nil {
+		t.Errorf("want no error, got: %v", err)
+	}
+	wants = []string{
+		"product /product1/ is unbound to any target, no need to verify",
+		"product /product/ is unbound to any target, no need to verify",
+		"verifying apps associated with product /product2/:",
+		"  app /app1/ associated with product /product2/ is verified",
+		"verifying apps associated with product /product0/:",
+		"  app /app0/ associated with product /product0/ is not associated with remote-service product",
+		"no app is found associated with product /product4/",
+	}
+	print.Check(t, wants)
+}
+
+func TestBindingVerifyOne(t *testing.T) {
+	print := testutil.Printer("TestBindingVerify")
+	ts := productTestServer(t)
+	defer ts.Close()
+
+	var err error
+	var flags []string
+	var rootCmd *cobra.Command
+	var rootArgs *shared.RootArgs
+	var wants []string
+
+	flags = []string{"bindings", "verify", "/product2/", "--opdk", "--runtime", ts.URL,
+		"-o", "/org/", "-e", "/env/", "-u", "/username/", "-p", "password"}
+	rootArgs = &shared.RootArgs{}
+	rootCmd = cmd.GetRootCmd(flags, print.Printf)
+	shared.AddCommandWithFlags(rootCmd, rootArgs, Cmd(rootArgs, print.Printf))
+	if err = rootCmd.Execute(); err != nil {
+		t.Errorf("want no error, got: %v", err)
+	}
+	wants = []string{
+		"verifying apps associated with product /product2/:",
+		"  app /app1/ associated with product /product2/ is verified",
+	}
+	print.Check(t, wants)
+}
+
 func productTestServer(t *testing.T) *httptest.Server {
 
-	res := product.APIResponse{
+	prods := product.APIResponse{
 		APIProducts: []product.APIProduct{
 			{
 				Name: "/product1/",
@@ -189,15 +261,155 @@ func productTestServer(t *testing.T) *httptest.Server {
 				QuotaLimit: "null",
 				Scopes:     []string{""},
 			},
+			{
+				Name: "/product0/",
+				Attributes: []product.Attribute{
+					{
+						Name:  product.TargetsAttr,
+						Value: "/target/",
+					},
+				},
+				QuotaLimit: "null",
+				Scopes:     []string{""},
+			},
+			{
+				Name: "/product4/",
+				Attributes: []product.Attribute{
+					{
+						Name:  product.TargetsAttr,
+						Value: "/target/",
+					},
+				},
+				QuotaLimit: "null",
+				Scopes:     []string{""},
+			},
+		},
+	}
+	apps := apigee.AppResponse{
+		Apps: []apigee.Application{
+			{
+				AppID: "0",
+				Name:  "/app0/",
+				Credentials: []apigee.Credential{
+					{
+						APIProducts: []apigee.APIProductRef{
+							{
+								Name:   "/product0/",
+								Status: "approved",
+							},
+						},
+					},
+				},
+			},
+			{
+				AppID: "1",
+				Name:  "/app1/",
+				Credentials: []apigee.Credential{
+					{
+						APIProducts: []apigee.APIProductRef{
+							{
+								Name:   "/product2/",
+								Status: "approved",
+							},
+							{
+								Name:   "remote-service",
+								Status: "approved",
+							},
+						},
+					},
+				},
+			},
+			{
+				AppID: "2",
+				Name:  "/app2/",
+				Credentials: []apigee.Credential{
+					{
+						APIProducts: []apigee.APIProductRef{
+							{
+								Name:   "remote-service",
+								Status: "approved",
+							},
+						},
+					},
+				},
+			},
+			{
+				AppID: "3",
+				Name:  "/app3/",
+				Credentials: []apigee.Credential{
+					{
+						APIProducts: []apigee.APIProductRef{
+							{
+								Name:   "remote-service",
+								Status: "approved",
+							},
+						},
+					},
+					{
+						APIProducts: []apigee.APIProductRef{
+							{
+								Name:   "/product3/",
+								Status: "approved",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	m := http.NewServeMux()
+	m.HandleFunc("/v1/organizations/org/apiproducts", (func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(res); err != nil {
+		if err := json.NewEncoder(w).Encode(prods); err != nil {
 			t.Fatalf("want no error %v", err)
 		}
 	}))
+	m.HandleFunc("/v1/organizations/org/apps", (func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(apps); err != nil {
+			t.Fatalf("want no error %v", err)
+		}
+	}))
+	m.HandleFunc("/v1/organizations/org/apiproducts/product1", (func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(prods.APIProducts[0]); err != nil {
+			t.Fatalf("want no error %v", err)
+		}
+	}))
+	m.HandleFunc("/v1/organizations/org/apiproducts/product", (func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(prods.APIProducts[1]); err != nil {
+			t.Fatalf("want no error %v", err)
+		}
+	}))
+	m.HandleFunc("/v1/organizations/org/apiproducts/product2", (func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(prods.APIProducts[2]); err != nil {
+			t.Fatalf("want no error %v", err)
+		}
+	}))
+	m.HandleFunc("/v1/organizations/org/apiproducts/product/attributes", (func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(prods.APIProducts[1]); err != nil {
+			t.Fatalf("want no error %v", err)
+		}
+	}))
+	m.HandleFunc("/v1/organizations/org/apiproducts/product2/attributes", (func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(prods.APIProducts[2]); err != nil {
+			t.Fatalf("want no error %v", err)
+		}
+	}))
+	return httptest.NewServer(m)
 }
 
 func testBindingsParams(t *testing.T, args ...string) {

--- a/cmd/bindings/bindings_test.go
+++ b/cmd/bindings/bindings_test.go
@@ -230,7 +230,7 @@ func TestBindingVerifyAll(t *testing.T) {
 		"verifying apps associated with product /product2/:",
 		"  app /app1/ associated with product /product2/ is verified",
 		"verifying apps associated with product /product0/:",
-		"  app /app0/ associated with product /product0/ is not associated with remote-service product",
+		"  app /app0/ associated with product /product0/ is verified",
 		"no app is found associated with product /product4/",
 	}
 	print.Check(t, wants)
@@ -317,6 +317,10 @@ func productTestServer(t *testing.T) *httptest.Server {
 						APIProducts: []apigee.APIProductRef{
 							{
 								Name:   "/product0/",
+								Status: "approved",
+							},
+							{
+								Name:   "remote-service",
 								Status: "approved",
 							},
 						},

--- a/go.sum
+++ b/go.sum
@@ -8,12 +8,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/apigee/apigee-remote-service-envoy v1.0.0 h1:oQ2p0LNYpFVI5sPmTLqUsuBtmMkzqSEwMaWDgkvQdkg=
-github.com/apigee/apigee-remote-service-envoy v1.0.0/go.mod h1:XeXbJQg54nakwFcQi+OwC2Vin08xaJtLwCFPioTwieU=
 github.com/apigee/apigee-remote-service-envoy v1.0.1-0.20200804175757-cbe957d201e9 h1:Q0N2BULt+MiFS+5HcNHu5g77t9TXR9GO9CeX95kVdFU=
 github.com/apigee/apigee-remote-service-envoy v1.0.1-0.20200804175757-cbe957d201e9/go.mod h1:tdiZ7S3Ju+zB1kq2UbDzM4R74im/KgUJrCezC4CnLj0=
-github.com/apigee/apigee-remote-service-golib v1.0.0 h1:oIYMFFGW0YcMyGrggJ2uuVgUPkjCgQSQjDTb8yxuoao=
-github.com/apigee/apigee-remote-service-golib v1.0.0/go.mod h1:C8zgor6NPXg1e8pVdOxAM3N3w4QmxLcY9lnLJl/VOd8=
 github.com/apigee/apigee-remote-service-golib v1.0.1-0.20200804164710-3c3cefe945df h1:IiAdorcDRQt+MfIKPCX7wjKWiIKoVRg/BZqw5Oxmt44=
 github.com/apigee/apigee-remote-service-golib v1.0.1-0.20200804164710-3c3cefe945df/go.mod h1:C8zgor6NPXg1e8pVdOxAM3N3w4QmxLcY9lnLJl/VOd8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
`./cli bindings verify [product name (optional)]` now serves as a linter that solves #31 

`./cli bindings list [product name (optional)]` now also takes the optional product name argument to list the information of that specific Apigee API product. No breaking change is expected.

`getProduct()` now just fetches one product from the specific endpoint.