### PR TITLE
Added analytics service account support

### DIFF
--- a/cmd/provision/config.go
+++ b/cmd/provision/config.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -38,7 +39,8 @@ const (
 	defaultApigeeCertFile = "/opt/apigee/tls/tls.crt"
 	defaultApigeeKeyFile  = "/opt/apigee/tls/tls.key"
 
-	policySecretNameFormat = "%s-%s-policy-secret"
+	policySecretNameFormat    = "%s-%s-policy-secret"
+	analyticsSecretNameFormat = "%s-%s-analytics-secret"
 )
 
 func (p *provision) createConfig(cred *keySecret) *server.Config {
@@ -105,12 +107,12 @@ func (p *provision) printConfig(config *server.Config, printf shared.FormatFn, v
 		return err
 	}
 
-	// secret for IsGCPManaged
+	// secrets for IsGCPManaged
 	if p.IsGCPManaged {
 		privateKeyBytes := pem.EncodeToMemory(&pem.Block{Type: server.PEMKeyType,
 			Bytes: x509.MarshalPKCS1PrivateKey(config.Tenant.PrivateKey)})
 
-		// create CRD for secret
+		// create CRD for policy secret
 		jwksBytes, err := json.Marshal(config.Tenant.JWKS)
 		if err != nil {
 			return err
@@ -122,6 +124,7 @@ func (p *provision) printConfig(config *server.Config, printf shared.FormatFn, v
 			return err
 		}
 
+		// encode policy secret
 		secretData := map[string]string{
 			server.SecretJKWSKey:    base64.StdEncoding.EncodeToString(jwksBytes),
 			server.SecretPrivateKey: base64.StdEncoding.EncodeToString(privateKeyBytes),
@@ -142,6 +145,34 @@ func (p *provision) printConfig(config *server.Config, printf shared.FormatFn, v
 		err = yamlEncoder.Encode(secretCRD)
 		if err != nil {
 			return err
+		}
+
+		// load analytics service account credentials
+		if p.serviceAccount != "" {
+			cred, err := ioutil.ReadFile(p.serviceAccount)
+			if err != nil {
+				return err
+			}
+
+			// encode service account credentials into secret
+			secretData := map[string]string{
+				server.ServiceAccount: base64.StdEncoding.EncodeToString(cred),
+			}
+			secretCRD := server.SecretCRD{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Type:       "Opaque",
+				Metadata: server.Metadata{
+					Name:      fmt.Sprintf(analyticsSecretNameFormat, p.Org, p.Env),
+					Namespace: p.Namespace,
+				},
+				Data: secretData,
+			}
+
+			err = yamlEncoder.Encode(secretCRD)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/provision/config.go
+++ b/cmd/provision/config.go
@@ -126,7 +126,7 @@ func (p *provision) printConfig(config *server.Config, printf shared.FormatFn, v
 
 		// encode policy secret
 		secretData := map[string]string{
-			server.SecretJKWSKey:    base64.StdEncoding.EncodeToString(jwksBytes),
+			server.SecretJWKSKey:    base64.StdEncoding.EncodeToString(jwksBytes),
 			server.SecretPrivateKey: base64.StdEncoding.EncodeToString(privateKeyBytes),
 			server.SecretPropsKey:   base64.StdEncoding.EncodeToString(propsBuf.Bytes()),
 		}

--- a/cmd/provision/config_test.go
+++ b/cmd/provision/config_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/apigee/apigee-remote-service-cli/shared"
 	"github.com/apigee/apigee-remote-service-cli/testutil"
 	"github.com/apigee/apigee-remote-service-envoy/server"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestEncodedName(t *testing.T) {

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -104,7 +104,7 @@ to your organization and environment.`,
 	c.Flags().StringVarP(&rootArgs.MFAToken, "mfa", "", "",
 		"Apigee multi-factor authorization token (legacy only)")
 
-	c.Flags().StringVarP(&p.serviceAccount, "service-account", "", "",
+	c.Flags().StringVarP(&p.serviceAccount, "analytics-sa", "", "",
 		"path to the service account json file (for GCP-managed analytics only)")
 
 	c.Flags().BoolVarP(&p.forceProxyInstall, "force-proxy-install", "f", false,

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -59,6 +59,7 @@ type provision struct {
 	forceProxyInstall bool
 	virtualHosts      string
 	rotate            int
+	serviceAccount    string
 }
 
 // Cmd returns base command
@@ -102,6 +103,9 @@ to your organization and environment.`,
 		"Apigee password (legacy or OPDK only)")
 	c.Flags().StringVarP(&rootArgs.MFAToken, "mfa", "", "",
 		"Apigee multi-factor authorization token (legacy only)")
+
+	c.Flags().StringVarP(&p.serviceAccount, "service-account", "", "",
+		"path to the service account json file (for GCP-managed analytics only)")
 
 	c.Flags().BoolVarP(&p.forceProxyInstall, "force-proxy-install", "f", false,
 		"force new proxy install (upgrades proxy)")

--- a/cmd/samples/samples.go
+++ b/cmd/samples/samples.go
@@ -122,7 +122,7 @@ files related to deployment of their target services.`,
 
 func (s *samples) loadConfig() error {
 	s.ServerConfig = &server.Config{}
-	err := s.ServerConfig.Load(s.ConfigPath, "")
+	err := s.ServerConfig.Load(s.ConfigPath, "", "")
 	if err != nil {
 		return err
 	}

--- a/cmd/token/token_test.go
+++ b/cmd/token/token_test.go
@@ -521,7 +521,7 @@ func generateConfig(t *testing.T) []byte {
 	}
 
 	secretData := map[string]string{
-		server.SecretJKWSKey:    base64.StdEncoding.EncodeToString(jwksBytes),
+		server.SecretJWKSKey:    base64.StdEncoding.EncodeToString(jwksBytes),
 		server.SecretPrivateKey: base64.StdEncoding.EncodeToString(privateKeyBytes),
 		server.SecretPropsKey:   base64.StdEncoding.EncodeToString(propsBuf.Bytes()),
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,6 @@ module github.com/apigee/apigee-remote-service-cli
 
 go 1.15
 
-//replace github.com/apigee/apigee-remote-service-golib => ../apigee-remote-service-golib
-
-//replace github.com/apigee/apigee-remote-service-envoy => ../apigee-remote-service-envoy
-
 require (
 	github.com/apigee/apigee-remote-service-envoy v1.1.0
 	github.com/apigee/apigee-remote-service-golib v1.1.0
@@ -14,6 +10,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	go.uber.org/multierr v1.5.0
-	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/apigee/apigee-remote-service-cli
 
 go 1.15
 
-// replace github.com/apigee/apigee-remote-service-golib => ../apigee-remote-service-golib
+//replace github.com/apigee/apigee-remote-service-golib => ../apigee-remote-service-golib
 
-// replace github.com/apigee/apigee-remote-service-envoy => ../apigee-remote-service-envoy
+//replace github.com/apigee/apigee-remote-service-envoy => ../apigee-remote-service-envoy
 
 require (
 	github.com/apigee/apigee-remote-service-envoy v1.1.0
@@ -14,5 +14,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	go.uber.org/multierr v1.5.0
+	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/apigee/apigee-remote-service-cli
 go 1.15
 
 require (
-	github.com/apigee/apigee-remote-service-envoy v1.1.0
-	github.com/apigee/apigee-remote-service-golib v1.1.0
+	github.com/apigee/apigee-remote-service-envoy v1.1.1-0.20200902195816-cdc62a2fae60
+	github.com/apigee/apigee-remote-service-golib v1.1.1-0.20200902192348-9e26efe438ba
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/lestrrat-go/jwx v1.0.4
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -19,10 +19,10 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apigee/apigee-remote-service-envoy v1.1.0 h1:okO/mP5yMDSrVjdyuRUNSodf0VudZ0/HQT5wC8grIyk=
-github.com/apigee/apigee-remote-service-envoy v1.1.0/go.mod h1:lfFJZI2uES3IStm935VKC32W0WTexva3DnAPHkXNOow=
-github.com/apigee/apigee-remote-service-golib v1.1.0 h1:Lu96m8GZoxDBJDKoqFbXqisuGjr0IBQLMXF7lN5HezM=
-github.com/apigee/apigee-remote-service-golib v1.1.0/go.mod h1:tGtrOAPlvl8uXd34oHpjm6BivAoMLZ3rJK/AqqJxJk0=
+github.com/apigee/apigee-remote-service-envoy v1.1.1-0.20200902195816-cdc62a2fae60 h1:2Hh/7rkXlHlNqSaIvRPKjOnzz36wVQWAPDR2pmyowKk=
+github.com/apigee/apigee-remote-service-envoy v1.1.1-0.20200902195816-cdc62a2fae60/go.mod h1:l4atUGQXDIWTQYBdqGkzfs1FkfiUU8E1wi3VCC7cL6Q=
+github.com/apigee/apigee-remote-service-golib v1.1.1-0.20200902192348-9e26efe438ba h1:C1j1+/XSmTwGQbwydgflxm8Ma1opZ87Zs71MKqV0DGg=
+github.com/apigee/apigee-remote-service-golib v1.1.1-0.20200902192348-9e26efe438ba/go.mod h1:J/2GDsnbdp7dyVWCTlmVs6+Tz7VWIo1F9yoZvBhvwe0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -18,12 +19,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2c
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apigee/apigee-remote-service-envoy v1.1.0-rc.1 h1:t2K9GtQk/ZPGXnsCYGAnzvdU5TJd8kCd9QbAQ+wjOZI=
-github.com/apigee/apigee-remote-service-envoy v1.1.0-rc.1/go.mod h1:FTnN6brxUneiLIHJZobgj5HyWgfLVSzakWrhFB9uIzo=
 github.com/apigee/apigee-remote-service-envoy v1.1.0 h1:okO/mP5yMDSrVjdyuRUNSodf0VudZ0/HQT5wC8grIyk=
 github.com/apigee/apigee-remote-service-envoy v1.1.0/go.mod h1:lfFJZI2uES3IStm935VKC32W0WTexva3DnAPHkXNOow=
-github.com/apigee/apigee-remote-service-golib v1.1.0-rc.1 h1:ccHkKTCnxWWfHhynT8L9L+QB0IT95ODx+JPx5zx3rgc=
-github.com/apigee/apigee-remote-service-golib v1.1.0-rc.1/go.mod h1:tGtrOAPlvl8uXd34oHpjm6BivAoMLZ3rJK/AqqJxJk0=
 github.com/apigee/apigee-remote-service-golib v1.1.0 h1:Lu96m8GZoxDBJDKoqFbXqisuGjr0IBQLMXF7lN5HezM=
 github.com/apigee/apigee-remote-service-golib v1.1.0/go.mod h1:tGtrOAPlvl8uXd34oHpjm6BivAoMLZ3rJK/AqqJxJk0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -408,6 +405,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -469,6 +467,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -262,7 +262,7 @@ func (r *RootArgs) loadConfig() error {
 	}
 
 	r.ServerConfig = &server.Config{}
-	err := r.ServerConfig.Load(r.ConfigPath, "")
+	err := r.ServerConfig.Load(r.ConfigPath, "", "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Related to https://github.com/apigee/apigee-remote-service-envoy/issues/42

Now the provision command optionally takes a `--service-account` flag (specific to udca service account with role Apigee Analytics Agent) which is the path to the service account json file.

A new k8s Secret will be created with this service account credentials encoded. It will enable the adapter to directly upload analytics to UAP instead of the fluentd endpoint.

The dependency may need to be updated for the GitHub action to succeed. The -golib and then -envoy PRs will need to be merged first.