### PR TITLE
Officially supporting OAuth or SAML token for any Apigee type

### DIFF
--- a/apigee/edge_client.go
+++ b/apigee/edge_client.go
@@ -250,7 +250,9 @@ func NewEdgeClient(o *EdgeClientOptions) (*EdgeClient, error) {
 		if e != nil {
 			return nil, e
 		}
-		if o.MgmtURL == defaultBaseURL {
+		// not overriding if auth token is given
+		// otherwise enforcing oauth on legacy saas
+		if o.Auth.BearerToken == "" && o.MgmtURL == defaultBaseURL {
 			c.auth.MFAToken = o.Auth.MFAToken
 			e = c.getOAuthToken()
 			if e != nil {

--- a/cmd/bindings/bindings.go
+++ b/cmd/bindings/bindings.go
@@ -60,7 +60,7 @@ func Cmd(rootArgs *shared.RootArgs, printf shared.FormatFn) *cobra.Command {
 	c.PersistentFlags().BoolVarP(&rootArgs.IsOPDK, "opdk", "", false,
 		"Apigee opdk")
 	c.PersistentFlags().StringVarP(&rootArgs.Token, "token", "t", "",
-		"Apigee OAuth or SAML token (hybrid only)")
+		"Apigee OAuth or SAML token (overrides any other given credentials)")
 	c.PersistentFlags().StringVarP(&rootArgs.Username, "username", "u", "",
 		"Apigee username (legacy or OPDK only)")
 	c.PersistentFlags().StringVarP(&rootArgs.Password, "password", "p", "",

--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -96,7 +96,7 @@ to your organization and environment.`,
 		"Apigee opdk")
 
 	c.Flags().StringVarP(&rootArgs.Token, "token", "t", "",
-		"Apigee OAuth or SAML token (hybrid only)")
+		"Apigee OAuth or SAML token (overrides any other given credentials)")
 	c.Flags().StringVarP(&rootArgs.Username, "username", "u", "",
 		"Apigee username (legacy or OPDK only)")
 	c.Flags().StringVarP(&rootArgs.Password, "password", "p", "",


### PR DESCRIPTION
If `--token/-t` is specified, any other credentials such as `--username/-u` or `--password/-p` will be ignored. It's verified to work this way on CG SaaS.

Close #64 