### PR TITLE
Fixed serviceaccount crd

### DIFF
--- a/cmd/provision/config.go
+++ b/cmd/provision/config.go
@@ -252,8 +252,8 @@ func (p *provision) createSecretPropertyset(jwk []byte, privateKey []byte, props
 	return err
 }
 
-func (p *provision) serviceAccountCRD() *server.ConfigMapCRD {
-	return &server.ConfigMapCRD{
+func (p *provision) serviceAccountCRD() *ServiceAccountCRD {
+	return &ServiceAccountCRD{
 		APIVersion: "v1",
 		Kind:       "ServiceAccount",
 		Metadata: server.Metadata{
@@ -261,4 +261,10 @@ func (p *provision) serviceAccountCRD() *server.ConfigMapCRD {
 			Namespace: p.Namespace,
 		},
 	}
+}
+
+type ServiceAccountCRD struct {
+	APIVersion string          `yaml:"apiVersion"`
+	Kind       string          `yaml:"kind"`
+	Metadata   server.Metadata `yaml:"metadata"`
 }


### PR DESCRIPTION
Reusing the ConfigMapCRD struct in #100 caused a invalid `data` field in the ServiceAccount resource.

This is a fix to it.