### PR TITLE
Change XML to JSON policy to find XML where it's stored

### DIFF
--- a/proxies/remote-proxy-gcp/apiproxy/policies/Products-to-JSON.xml
+++ b/proxies/remote-proxy-gcp/apiproxy/policies/Products-to-JSON.xml
@@ -4,7 +4,7 @@
     <FaultRules/>
     <Properties/>
     <OutputVariable>apiCredential</OutputVariable>
-    <Source>AccessEntity.ChildNodes.Access-App-Info.App.Credentials</Source>
+    <Source>AccessEntity.Access-App-Info.App.Credentials</Source>
     <Options>
         <TreatAsArray>
             <Path>Credentials/Credential</Path>


### PR DESCRIPTION
On Apigee Ng SaaS, it looks like the AccessEntity policy does not
add a "ChildNodes" component to the name of the thing that
we're looking for. As a result, without this change, API key validation
does not work because this policy does not produce any output.

I can verify that in my environment, which is running Apigee as a service on GCP, verifying API keys does not work without this change. I don't know how this gets tested in this project, however, or whether this change is due to a change in Apigee or for some other reason.