### PR TITLE
checking certain status codes in remote-service proxy verification

### DIFF
--- a/cmd/provision/proxy.go
+++ b/cmd/provision/proxy.go
@@ -269,19 +269,3 @@ func zipDir(source, file string) error {
 
 	return w.Close()
 }
-
-type apiProduct struct {
-	Name         string      `json:"name,omitempty"`
-	DisplayName  string      `json:"displayName,omitempty"`
-	ApprovalType string      `json:"approvalType,omitempty"`
-	Attributes   []attribute `json:"attributes,omitempty"`
-	Description  string      `json:"description,omitempty"`
-	APIResources []string    `json:"apiResources,omitempty"`
-	Environments []string    `json:"environments,omitempty"`
-	Proxies      []string    `json:"proxies,omitempty"`
-}
-
-type attribute struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
-}


### PR DESCRIPTION
`verifyRemoteServiceProxy` is not checking the response status code to ensure the GET request is getting a code among (200, 401, 500) and POST request is getting (401).

Open to improvements.

Removed some unused code since the remote-service API product creation is removed.

close #123 
