### PR TITLE
added 200 to checked status codes for /quota endpoint

### DIFF
--- a/cmd/provision/provision.go
+++ b/cmd/provision/provision.go
@@ -485,7 +485,7 @@ func (p *provision) verifyRemoteServiceProxy(client *http.Client, printf shared.
 		res, err = client.Do(req)
 		if res != nil {
 			defer res.Body.Close()
-			if res.StatusCode != http.StatusUnauthorized { // 401 is ok, we didn't use a valid api key
+			if res.StatusCode != http.StatusUnauthorized && res.StatusCode != http.StatusOK {
 				verifyErrors = multierr.Append(verifyErrors, fmt.Errorf("POST request to %q returns %d", quotasURL, res.StatusCode))
 			}
 		}

--- a/cmd/provision/provision_test.go
+++ b/cmd/provision/provision_test.go
@@ -37,8 +37,11 @@ func TestVerifyRemoteServiceProxyTLS(t *testing.T) {
 
 	count := 0
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 401 is accepted status code for most endpoints since no internal JWT used
-		w.WriteHeader(http.StatusUnauthorized)
+		if strings.Contains(r.URL.Path, "verifyApiKey") {
+			w.WriteHeader(http.StatusUnauthorized)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
 		count++
 	}))
 	defer ts.Close()
@@ -260,8 +263,11 @@ func serveMux(t *testing.T) *http.ServeMux {
 	})
 	// catch-all handler for remote service proxy verification
 	m.HandleFunc("/remote-service/", func(w http.ResponseWriter, r *http.Request) {
-		// 401 is accepted status code for most endpoints since no internal JWT used
-		w.WriteHeader(http.StatusUnauthorized)
+		if strings.Contains(r.URL.Path, "verifyApiKey") {
+			w.WriteHeader(http.StatusUnauthorized)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
 	})
 	m.HandleFunc("/v1/organizations/gcp", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {


### PR DESCRIPTION
The last PR #126 should have returned an error when /quota returns 200 given a correctly authorized http client.

Somehow there was no problem with the integration test. For hybrid it's understandable since the new secret hasn't been applied to the cluster so it should indeed return 401. Not sure why cgsaas and opdk case had no failure at all.

Related to #123 