### PR TITLE
Add the 'application_id' claim to the '/verifyApiKey' response

### DIFF
--- a/cmd/provision/proxies/remote-service-gcp/apiproxy/policies/Generate-VerifyKey-Token.xml
+++ b/cmd/provision/proxies/remote-service-gcp/apiproxy/policies/Generate-VerifyKey-Token.xml
@@ -13,6 +13,7 @@
     <AdditionalClaims>
         <Claim name="client_id" ref="apikey"/>
         <Claim name="api_product_list" ref="apiProductList" type="string" array="true"/>
+        <Claim name="application_id" ref="AccessEntity.ChildNodes.Access-App-Info.App.AppId"/>
         <Claim name="application_name" ref="appName"/>
         <Claim name="developer_email" ref="AccessEntity.ChildNodes.Access-Developer-Info.Developer.Email"/>
     </AdditionalClaims>

--- a/cmd/provision/proxies/remote-service-legacy/apiproxy/policies/Generate-VerifyKey-Token.xml
+++ b/cmd/provision/proxies/remote-service-legacy/apiproxy/policies/Generate-VerifyKey-Token.xml
@@ -13,6 +13,7 @@
     <AdditionalClaims>
         <Claim name="client_id" ref="apikey"/>
         <Claim name="api_product_list" ref="apiProductList" type="string" array="true"/>
+        <Claim name="application_id" ref="AccessEntity.ChildNodes.Access-App-Info.App.AppId"/>
         <Claim name="application_name" ref="appName"/>
         <Claim name="developer_email" ref="AccessEntity.ChildNodes.Access-Developer-Info.Developer.Email"/>
     </AdditionalClaims>


### PR DESCRIPTION
When third parties integrate with the Apigee Remote Service, it can be useful to know the application id of the application that an API key corresponds to. The reason for this is two fold:

1. The current information in the response is not enough to guarantee the uniqueness of an application because the 'application_name' claim can be duplicated across applications over time. (For example, you can create an applicaiton 'foo', delete it and then create a new application 'foo' and it will have the same 'application_name' but not the same 'application_id'.)

2. While the 'client_id' is unique, it is considered sensitive information and there are applications where using this might cause this information to leak.