### PR TITLE
Bump golang version and update unit tests to reflect new mtls error string

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.21
       - 
         name: Reviewdog Lint
         uses: reviewdog/action-golangci-lint@v1
@@ -48,7 +48,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.21
       - 
         name: Run Unit tests
         run: go test -coverprofile=coverage.txt ./...

--- a/apigee/edge_client_test.go
+++ b/apigee/edge_client_test.go
@@ -283,7 +283,7 @@ func TestMutualTLSNoCerts(t *testing.T) {
 	}
 
 	_, err = c.Do(req, nil)
-	testutil.ErrorContains(t, err, "remote error: tls: bad certificate")
+	testutil.ErrorContains(t, err, "remote error: tls: certificate required")
 }
 
 func newMutualTLSServer() *httptest.Server {


### PR DESCRIPTION
In newer golang versions (likely from [this change](https://cs.opensource.google/go/go/+/62a994837a57a7d0c58bb364b580a389488446c9)), the cli unit tests fail with:

```
--- FAIL: TestMutualTLSNoCerts (0.01s)
    edge_client_test.go:286: want remote error: tls: bad certificate, got Get "https://127.0.0.1:35291/v1/organizations/org/environments/env": remote error: tls: certificate required 
```

Updating the unit test to reflect the current error string.